### PR TITLE
Update R-Universe for SeuratObject v4

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,8 +1,8 @@
 [    
     {
         "package": "SeuratObject",
-        "url": "https://github.com/mojaveazure/seurat-object",
-        "branch": "seurat4"
+        "url": "https://github.com/satijalab/seurat-object",
+        "branch": "v4.1.4"
     },
     {
         "package": "Seurat",


### PR DESCRIPTION
Update R-universe entry for SeuratObject v4:
- point to satijalab GH repo
- use release tag instead of branch (I want to do a branch cleanup of SeuratObject)

v5 release is hosted on CRAN, current development version `develop` is hosted on https://mojaveazure.r-universe.dev/SeuratObject