### PR TITLE
Add enrichR to R-Universe

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -12,5 +12,9 @@
     {
         "package": "presto",
         "url": "https://github.com/immunogenomics/presto"
+    },
+    {
+        "package": "enrichR",
+        "url": "https://github.com/wjawaid/enrichR"
     }
 ]


### PR DESCRIPTION
This PR adds the `enrichR` package to `satijalab.r-universe.dev` in an effort to address the following NOTE currently being thrown by `R CMD check` for `Seurat`:

```R
* checking CRAN incoming feasibility ... [31s] NOTE
Maintainer: 'Rahul Satija <seurat@nygenome.org>'

Suggests or Enhances not in mainstream repositories:
  BPCells, enrichR, presto
Availability using Additional_repositories specification:
  BPCells   yes   https://bnprks.r-universe.dev   
  presto    yes   https://satijalab.r-universe.dev
  enrichR    no   ?                               
  ?           ?   https://cran.r-universe.dev  
```

In https://github.com/satijalab/seurat/pull/9565 we tried to address this issue by adding the `cran.r-universe.dev` remote—`enrichR` has since been dropped from this too 😢 

Unless I'm missing some downside, adding the package to our universe seems like the easiest/best way to unblock https://github.com/satijalab/seurat/pull/9567. Once `enrichR` makes it back onto CRAN, we can drop it from the `packages.json` and things should go back to business as usual, with no updates to `Seurat` needed 👌 

